### PR TITLE
feat: release 0.142-0deepin1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+initramfs-tools (0.142-0deepin1) unstable; urgency=medium
+
+  * Backport patches from 0.143 as we are locked in on 0.142.
+  * Use dracut-install to install modules, resolving an issue in which
+    symlinks were resolved into normal files, causing duplicates and inflated
+    initramfs sizes (since NVIDIA GSP introduction in 6.7).
+  * Add support for compressed firmware data.
+  * Declare zstd as a dependency as we don't install Recommends by default.
+
+ -- Mingcong Bai <baimingcong@uniontech.com>  Thu, 01 Aug 2024 14:40:44 +0800
+
 initramfs-tools (0.142) unstable; urgency=medium
 
   [ Dan Streetman ]

--- a/debian/control
+++ b/debian/control
@@ -25,8 +25,16 @@ Description: generic modular initramfs generator (automation)
 Package: initramfs-tools-core
 Architecture: all
 Multi-Arch: foreign
-Recommends: ${busybox:Recommends}, zstd
-Depends: klibc-utils (>= 2.0.4-8~), cpio (>= 2.12), kmod, udev, coreutils (>= 8.24), logsave | e2fsprogs (<< 1.45.3-1~), ${misc:Depends}
+Recommends: ${busybox:Recommends}
+Depends: coreutils (>= 8.24),
+         cpio (>= 2.12),
+         dracut-install,
+         klibc-utils (>= 2.0.4-8~),
+         kmod,
+         logsave | e2fsprogs (<< 1.45.3-1~),
+         udev,
+         zstd,
+         ${misc:Depends}
 Suggests: bash-completion
 Breaks: initramfs-tools (<< 0.121~), ${busybox:Breaks}
 Replaces: initramfs-tools (<< 0.121~)

--- a/debian/source/format
+++ b/debian/source/format
@@ -1,1 +1,1 @@
-3.0 (native)
+3.0 (quilt)

--- a/hook-functions
+++ b/hook-functions
@@ -623,14 +623,14 @@ auto_add_modules()
 			copy_modules_dir kernel/drivers/usb/host \
 				hwa-hc.ko sl811_cs.ko sl811-hcd.ko \
 				u132-hcd.ko whci-hcd.ko
-			copy_modules_dir kernel/drivers/usb/c67x00
-			copy_modules_dir kernel/drivers/usb/chipidea
-			copy_modules_dir kernel/drivers/usb/dwc2
-			copy_modules_dir kernel/drivers/usb/dwc3
-			copy_modules_dir kernel/drivers/usb/isp1760
-			copy_modules_dir kernel/drivers/usb/musb
-			copy_modules_dir kernel/drivers/usb/renesas_usbhs
-			copy_modules_dir kernel/drivers/usb/typec/tcpm
+			modules="$modules =drivers/usb/c67x00"
+			modules="$modules =drivers/usb/chipidea"
+			modules="$modules =drivers/usb/dwc2"
+			modules="$modules =drivers/usb/dwc3"
+			modules="$modules =drivers/usb/isp1760"
+			modules="$modules =drivers/usb/musb"
+			modules="$modules =drivers/usb/renesas_usbhs"
+			modules="$modules =drivers/usb/typec/tcpm"
 			# and any extcon drivers for USB
 			modules="$modules extcon-usb-gpio extcon-usbc-cros-ec"
 			# Add the axp20x_usb_power power supply driver,
@@ -642,7 +642,7 @@ auto_add_modules()
 			# unless we're sure they don't support keyboards.
 			# hid-*ff covers various game controllers with
 			# force feedback.
-			copy_modules_dir kernel/drivers/input/keyboard
+			modules="$modules =drivers/input/keyboard"
 			copy_modules_dir kernel/drivers/hid \
 				'hid-*ff.ko' hid-a4tech.ko hid-cypress.ko \
 				hid-dr.ko hid-elecom.ko hid-gyration.ko \
@@ -660,22 +660,22 @@ auto_add_modules()
 			modules="$modules cros_ec_spi"
 
 			# Any of these might be needed by other drivers
-			copy_modules_dir kernel/drivers/bus
-			copy_modules_dir kernel/drivers/clk
-			copy_modules_dir kernel/drivers/gpio
-			copy_modules_dir kernel/drivers/i2c/busses
-			copy_modules_dir kernel/drivers/i2c/muxes
-			copy_modules_dir kernel/drivers/mfd
-			copy_modules_dir kernel/drivers/pci/controller
-			copy_modules_dir kernel/drivers/phy
-			copy_modules_dir kernel/drivers/pinctrl
-			copy_modules_dir kernel/drivers/regulator
-			copy_modules_dir kernel/drivers/reset
-			copy_modules_dir kernel/drivers/spi
-			copy_modules_dir kernel/drivers/usb/phy
+			modules="$modules =drivers/bus"
+			modules="$modules =drivers/clk"
+			modules="$modules =drivers/gpio"
+			modules="$modules =drivers/i2c/busses"
+			modules="$modules =drivers/i2c/muxes"
+			modules="$modules =drivers/mfd"
+			modules="$modules =drivers/pci/controller"
+			modules="$modules =drivers/phy"
+			modules="$modules =drivers/pinctrl"
+			modules="$modules =drivers/regulator"
+			modules="$modules =drivers/reset"
+			modules="$modules =drivers/spi"
+			modules="$modules =drivers/usb/phy"
 
 			# Needed for periodic fsck
-			copy_modules_dir kernel/drivers/rtc
+			modules="$modules =drivers/rtc"
 		;;
 		net)
 			copy_modules_dir kernel/drivers/net \
@@ -694,22 +694,22 @@ auto_add_modules()
 			modules="$modules nvmem-imx-ocotp"
 		;;
 		ide)
-			copy_modules_dir kernel/drivers/ide
+			modules="$modules =drivers/ide"
 		;;
 		mmc)
-			copy_modules_dir kernel/drivers/mmc
+			modules="$modules =drivers/mmc"
 		;;
 		scsi)
-			copy_modules_dir kernel/drivers/scsi
-			copy_modules_dir kernel/drivers/ufs
+			modules="$modules =drivers/scsi"
+			modules="$modules =drivers/ufs"
 			modules="$modules mptfc mptsas mptscsih mptspi zfcp"
 		;;
 		ata)
-			copy_modules_dir kernel/drivers/ata
+			modules="$modules =drivers/ata"
 		;;
 		block)
-			copy_modules_dir kernel/drivers/block
-			copy_modules_dir kernel/drivers/nvme
+			modules="$modules =drivers/block"
+			modules="$modules =drivers/nvme"
 			modules="$modules vmd"
 		;;
 		ubi)
@@ -722,7 +722,7 @@ auto_add_modules()
 			modules="$modules dasd_diag_mod dasd_eckd_mod dasd_fba_mod"
 		;;
 		usb_storage)
-			copy_modules_dir kernel/drivers/usb/storage
+			modules="$modules =drivers/usb/storage"
 		;;
 		fb)
 			# For machines that don't have a generic framebuffer device.

--- a/hook-functions
+++ b/hook-functions
@@ -28,7 +28,7 @@ force_load()
 }
 
 # Takes a file containing a list of modules to be added as an
-# argument, figures out dependancies, and adds them.
+# argument, figures out dependencies, and adds them.
 #
 # Input file syntax:
 #
@@ -57,18 +57,23 @@ add_modules_from_file()
 # whether a warning should be printed in that case.)
 add_firmware()
 {
-	local firmware fwloc
+	local firmware fwloc fw_path_para path_firmware
 
 	firmware="${1}"
 
-	if [ -e "${DESTDIR}/lib/firmware/updates/${version?}/${firmware}" ] \
+	read -r fw_path_para < /sys/module/firmware_class/parameters/path
+
+	if { [ -n "$fw_path_para" ] && [ -e "${DESTDIR}/${fw_path_para}/${firmware}" ]; } \
+	|| [ -e "${DESTDIR}/lib/firmware/updates/${version?}/${firmware}" ] \
 	|| [ -e "${DESTDIR}/lib/firmware/updates/${firmware}" ] \
 	|| [ -e "${DESTDIR}/lib/firmware/${version}/${firmware}" ] \
 	|| [ -e "${DESTDIR}/lib/firmware/${firmware}" ]; then
 		return 0
 	fi
 
-	for fwloc in "/lib/firmware/updates/${version}/${firmware}" \
+	[ -n "$fw_path_para" ] && path_firmware="${fw_path_para}/${firmware}" || path_firmware=
+	for fwloc in "$path_firmware" \
+		"/lib/firmware/updates/${version}/${firmware}" \
 		"/lib/firmware/updates/${firmware}" \
 		"/lib/firmware/${version}/${firmware}" \
 		"/lib/firmware/${firmware}"; do

--- a/hook-functions
+++ b/hook-functions
@@ -85,47 +85,20 @@ add_firmware()
 # Add dependent modules + eventual firmware
 manual_add_modules()
 {
-	local prefix kmod options firmware
+	local dracut_verbose fw_path_para
 
 	if [ $# -eq 0 ]; then
 		return
 	fi
 
-	# modprobe --ignore-install inhibits processing of 'install'
-	# configuration lines, so that instead we will see 'insmod
-	# module.ko' as we want.  However it also means that 'softdep'
-	# configuration lines and embedded softdep information is not
-	# processed.  So we run twice, with and without this option.
-	# shellcheck disable=SC2034
-	{ /sbin/modprobe --all --set-version="${version?}" --ignore-install --quiet --show-depends "$@";
-	  /sbin/modprobe --all --set-version="${version}" --quiet --show-depends "$@"; } |
-	while read -r prefix kmod options ; do
-		if [ "${prefix}" != "insmod" ]; then
-			continue
-		fi
+	if [ "${verbose?}" = "y" ]; then
+		dracut_verbose=-v
+	fi
 
-		copy_file module "${kmod}" || continue
-
-		# Add required firmware
-		for firmware in $(modinfo -k "${version}" -F firmware "${kmod}"); do
-			# Only print warning for missing fw of loaded module
-			# or forced loaded module
-			if ! add_firmware "$firmware"; then
-				# Only warn about missing firmware if
-				# /proc/modules exists
-				if [ ! -e /proc/modules ] ; then
-					continue
-				fi
-
-				kmod_modname="${kmod##*/}"
-				kmod_modname="${kmod_modname%%.*}"
-				if grep -q "^$kmod_modname\\>" /proc/modules "${CONFDIR}/modules"; then
-					echo "W: Possible missing firmware /lib/firmware/${firmware} for module ${kmod_modname}" >&2
-				fi
-				continue
-			fi
-		done
-	done
+	read -r fw_path_para < /sys/module/firmware_class/parameters/path
+	/usr/lib/dracut/dracut-install -D "$DESTDIR" --kerneldir "/lib/modules/${version?}" \
+		--firmwaredirs "${fw_path_para:+${fw_path_para}:}/lib/firmware/updates/${version?}:/lib/firmware/updates:/lib/firmware/${version?}:/lib/firmware" \
+		${dracut_verbose-} -o -m "$@"
 }
 
 # manual_add_modules() takes care of adding firmware for things that were built

--- a/hook-functions
+++ b/hook-functions
@@ -543,6 +543,25 @@ dep_add_modules()
 		fi
 	done
 
+	# It's possible that a generic framebuffer device works, but is taken
+	# over by a more capable driver and no longer available in /sys. We
+	# have no reliable consistent way to detect that, so apply heuristics.
+	case "$(uname -m)" in
+		i386|i686|x86_64) walk_graphics=no ;;
+	esac
+
+	if [ -d "/sys/firmware/efi/efivars" ]; then
+		walk_graphics=no
+	fi
+
+	for node in /sys/firmware/devicetree/base/chosen/framebuffer@*; do
+		if [ -d "$node" ] && grep -qz '^simple-framebuffer$' "$node/compatible"; then
+			if [ ! -f "$node/status" ] || grep -qz '^\(okay\|ok\)$' "$node/status"; then
+				walk_graphics=no
+			fi
+		fi
+	done
+
 	if [ "$walk_graphics" = "yes" ]; then
 		class_add_modules backlight
 		class_add_modules graphics

--- a/hook-functions
+++ b/hook-functions
@@ -63,7 +63,7 @@ add_firmware()
 
 	read -r fw_path_para < /sys/module/firmware_class/parameters/path
 
-	for suffix in "" ".xz"; do
+	for suffix in "" ".zst" ".xz"; do
 		if { [ -n "$fw_path_para" ] && [ -e "${DESTDIR}/${fw_path_para}/${firmware}${suffix}" ]; } \
 		|| [ -e "${DESTDIR}/lib/firmware/updates/${version?}/${firmware}${suffix}" ] \
 		|| [ -e "${DESTDIR}/lib/firmware/updates/${firmware}${suffix}" ] \
@@ -73,7 +73,7 @@ add_firmware()
 		fi
 	done
 
-	for suffix in "" ".xz"; do
+	for suffix in "" ".zst" ".xz"; do
 		[ -n "$fw_path_para" ] && path_firmware="${fw_path_para}/${firmware}${suffix}" || path_firmware=
 		for fwloc in "$path_firmware" \
 			"/lib/firmware/updates/${version}/${firmware}${suffix}" \

--- a/hook-functions
+++ b/hook-functions
@@ -57,30 +57,34 @@ add_modules_from_file()
 # whether a warning should be printed in that case.)
 add_firmware()
 {
-	local firmware fwloc fw_path_para path_firmware
+	local firmware suffix fwloc fw_path_para path_firmware
 
 	firmware="${1}"
 
 	read -r fw_path_para < /sys/module/firmware_class/parameters/path
 
-	if { [ -n "$fw_path_para" ] && [ -e "${DESTDIR}/${fw_path_para}/${firmware}" ]; } \
-	|| [ -e "${DESTDIR}/lib/firmware/updates/${version?}/${firmware}" ] \
-	|| [ -e "${DESTDIR}/lib/firmware/updates/${firmware}" ] \
-	|| [ -e "${DESTDIR}/lib/firmware/${version}/${firmware}" ] \
-	|| [ -e "${DESTDIR}/lib/firmware/${firmware}" ]; then
-		return 0
-	fi
-
-	[ -n "$fw_path_para" ] && path_firmware="${fw_path_para}/${firmware}" || path_firmware=
-	for fwloc in "$path_firmware" \
-		"/lib/firmware/updates/${version}/${firmware}" \
-		"/lib/firmware/updates/${firmware}" \
-		"/lib/firmware/${version}/${firmware}" \
-		"/lib/firmware/${firmware}"; do
-		if [ -e "$fwloc" ]; then
-			copy_file firmware "$fwloc"
+	for suffix in "" ".xz"; do
+		if { [ -n "$fw_path_para" ] && [ -e "${DESTDIR}/${fw_path_para}/${firmware}${suffix}" ]; } \
+		|| [ -e "${DESTDIR}/lib/firmware/updates/${version?}/${firmware}${suffix}" ] \
+		|| [ -e "${DESTDIR}/lib/firmware/updates/${firmware}${suffix}" ] \
+		|| [ -e "${DESTDIR}/lib/firmware/${version}/${firmware}${suffix}" ] \
+		|| [ -e "${DESTDIR}/lib/firmware/${firmware}${suffix}" ]; then
 			return 0
 		fi
+	done
+
+	for suffix in "" ".xz"; do
+		[ -n "$fw_path_para" ] && path_firmware="${fw_path_para}/${firmware}${suffix}" || path_firmware=
+		for fwloc in "$path_firmware" \
+			"/lib/firmware/updates/${version}/${firmware}${suffix}" \
+			"/lib/firmware/updates/${firmware}${suffix}" \
+			"/lib/firmware/${version}/${firmware}${suffix}" \
+			"/lib/firmware/${firmware}${suffix}"; do
+			if [ -e "$fwloc" ]; then
+				copy_file firmware "$fwloc"
+				return 0
+			fi
+		done
 	done
 
 	# We can't figure out where to get that firmware from.

--- a/hook-functions
+++ b/hook-functions
@@ -83,7 +83,24 @@ add_firmware()
 }
 
 # Add dependent modules + eventual firmware
+# This function was changed to only collect the wanted kernel modules.
+# Call apply_add_modules to copy the kernel modules.
 manual_add_modules()
+{
+	for module in "$@"; do
+		echo "$module" >> "$__MODULES_TO_ADD"
+	done
+}
+
+# Copy the kernel modules that were marked in manual_add_modules
+apply_add_modules()
+{
+	# shellcheck disable=SC2046
+	_call_dracut_install $(sort -u "$__MODULES_TO_ADD")
+	true > "$__MODULES_TO_ADD"
+}
+
+_call_dracut_install()
 {
 	local dracut_verbose fw_path_para
 
@@ -711,7 +728,7 @@ auto_add_modules()
 hidden_dep_add_modules()
 {
 	# shellcheck disable=SC2046
-	manual_add_modules $(
+	_call_dracut_install $(
 		{
 			cat "${DESTDIR}/lib/modules/${version}/modules.builtin"
 			if [ -d "${DESTDIR}/lib/modules/${version}/kernel" ]; then

--- a/mkinitramfs
+++ b/mkinitramfs
@@ -261,6 +261,8 @@ DESTDIR=
 __TMPCPIOGZ=
 __TMPMAINCPIO=
 __TMPEARLYCPIO=
+__MODULES_TO_ADD=
+# shellcheck disable=SC2317
 clean_on_exit() {
 	if [ "${keep}" = "y" ]; then
 		echo "Working files in ${DESTDIR:-<not yet created>}," \
@@ -268,7 +270,7 @@ clean_on_exit() {
 			"main initramfs in ${__TMPMAINCPIO:-<not yet created>} and" \
 			"overlay in ${__TMPCPIOGZ:-<not yet created>}"
 	else
-		for path in "${DESTDIR}" "${__TMPCPIOGZ}" "${__TMPMAINCPIO}" "${__TMPEARLYCPIO}"; do
+		for path in "${DESTDIR}" "${__TMPCPIOGZ}" "${__TMPMAINCPIO}" "${__TMPEARLYCPIO}" "${__MODULES_TO_ADD}"; do
 			test -z "${path}" || rm -rf "${path}"
 		done
 	fi
@@ -283,6 +285,7 @@ chmod 755 "${DESTDIR}"
 __TMPCPIOGZ="$(mktemp "${TMPDIR:-/var/tmp}/mkinitramfs-OL_XXXXXX")" || exit 1
 __TMPMAINCPIO="$(mktemp "${TMPDIR:-/var/tmp}/mkinitramfs-MAIN_XXXXXX")" || exit 1
 __TMPEARLYCPIO="$(mktemp "${TMPDIR:-/var/tmp}/mkinitramfs-FW_XXXXXX")" || exit 1
+__MODULES_TO_ADD="$(mktemp "${TMPDIR:-/var/tmp}/modules_XXXXXX")" || exit 1
 
 DPKG_ARCH=$(dpkg --print-architecture)
 
@@ -305,6 +308,9 @@ export __TMPCPIOGZ
 
 # Private, used by 'prepend_earlyinitramfs'.
 export __TMPEARLYCPIO
+
+# Private, used by 'manual_add_modules'.
+export __MODULES_TO_ADD
 
 # Create usr-merged filesystem layout, to avoid duplicates if the host
 # filesystem is usr-merged.
@@ -409,6 +415,8 @@ for file in /etc/modprobe.d/*.conf /lib/modprobe.d/*.conf ; do
 	fi
 done
 
+# Copy kernel modules here, because some hooks rely on them being copied
+apply_add_modules
 run_scripts /usr/share/initramfs-tools/hooks
 run_scripts "${CONFDIR}"/hooks
 
@@ -416,6 +424,10 @@ run_scripts "${CONFDIR}"/hooks
 for b in $(cd "${DESTDIR}/scripts" && find . -mindepth 1 -type d); do
 	cache_run_scripts "${DESTDIR}" "/scripts/${b#./}"
 done
+
+apply_add_modules
+# Resolve hidden dependencies
+hidden_dep_add_modules
 
 # decompress modules for boot speed, if possible
 find "${DESTDIR}/${MODULESDIR}" -name '*.ko.*' | while read -r ko; do


### PR DESCRIPTION
- Backport patches from 0.143 as we are locked in on 0.142.
- Use dracut-install to install modules, resolving an issue in which symlinks were resolved into normal files, causing duplicates and inflated initramfs sizes (since NVIDIA GSP introduction in 6.7).
- Add support for compressed firmware data.
- Declare zstd as a dependency as we don't install Recommends by default.