### PR TITLE
feat(initramfs): add trace logging for performance analysis

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+initramfs-tools (0.142-0deepin14) unstable; urgency=medium
+
+  * Add uos-trace logging to initramfs for performance timing analysis 
+
+ -- xinpeng.wang <wangxinpeng@uniontech.com>  Tue, 02 Jun 2026 17:09:44 +0800
+
 initramfs-tools (0.142-0deepin13) unstable; urgency=medium
 
   * Implement disk cleanup mechanism in initramfs to handle full disk scenarios.

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -8,3 +8,4 @@ uniontech-check-init.patch
 uniontech-resolve-device-by-decreasing-priority.patch
 uniontech-Improve-boot-performance-using-lz4.patch
 uniontech-add-check-fs.patch
+uniontech-add-log-for-performance.patch

--- a/debian/patches/uniontech-add-log-for-performance.patch
+++ b/debian/patches/uniontech-add-log-for-performance.patch
@@ -1,0 +1,48 @@
+Index: deepin-initramfs-tools/hook-functions
+===================================================================
+--- deepin-initramfs-tools.orig/hook-functions
++++ deepin-initramfs-tools/hook-functions
+@@ -886,6 +886,8 @@ cache_run_scripts()
+ 	runlist=$(get_prereq_pairs | tsort)
+ 	for crs_x in ${runlist}; do
+ 		[ -f "${initdir}/${crs_x}" ] || continue
++		# shellcheck disable=SC2129
++		echo "echo \"uos-trace ${scriptdir}/${crs_x}\" > /dev/kmsg || true"  >> "${initdir}/ORDER"
+ 		echo "${scriptdir}/${crs_x} \"\$@\"" >> "${initdir}/ORDER"
+ 		echo "[ -e /conf/param.conf ] && . /conf/param.conf" >> "${initdir}/ORDER"
+ 	done
+Index: deepin-initramfs-tools/scripts/functions
+===================================================================
+--- deepin-initramfs-tools.orig/scripts/functions
++++ deepin-initramfs-tools/scripts/functions
+@@ -33,6 +33,11 @@ log_end_msg()
+ 	_log_msg "done.\\n"
+ }
+ 
++trace_log()
++{
++	echo "uos-trace: $*" > /dev/kmsg || true
++}
++
+ panic()
+ {
+ 	local console rest IFS
+Index: deepin-initramfs-tools/scripts/local
+===================================================================
+--- deepin-initramfs-tools.orig/scripts/local
++++ deepin-initramfs-tools/scripts/local
+@@ -176,12 +176,14 @@ local_mount_root()
+ 
+ 	# Mount root
+ 	# shellcheck disable=SC2086
++	trace_log "exec mount ${roflag} ${FSTYPE:+-t ${FSTYPE}} ${ROOTFLAGS} ${ROOT} ${rootmnt?}"
+ 	if ! mount ${roflag} ${FSTYPE:+-t "${FSTYPE}"} ${ROOTFLAGS} "${ROOT}" "${rootmnt?}"; then
+ 		panic "Failed to mount ${ROOT} as root file system."
+ 		# Mount root
+ 		# shellcheck disable=SC2086
+ 		mount ${roflag} ${FSTYPE:+-t "${FSTYPE}"} ${ROOTFLAGS} "${ROOT}" "${rootmnt?}"
+ 	fi
++	trace_log "mount end"
+ }
+ 
+ local_mount_fs()


### PR DESCRIPTION
Add trace_log() function that writes to /dev/kmsg with "uos-trace:" prefix.
- Insert trace before and after root mount operation in scripts/local
- Generate ORDER file with trace markers to show each script execution time

This enables performance analysis tools to capture precise timing of initramfs boot phases without affecting normal boot behavior. The logs can be collected via dmesg or /dev/kmsg for post-processing.

功能(initramfs): 增加性能统计用的跟踪日志

新增 trace_log() 函数，以 "uos-trace:" 前缀写入 /dev/kmsg。
- 在 scripts/local 中的根挂载操作前后插入跟踪点
- 生成 ORDER 文件时添加跟踪标记，记录每个脚本的执行时间

这使得性能分析工具能够精确捕获 initramfs 启动各阶段的耗时，
且不影响正常启动行为。日志可通过 dmesg 或 /dev/kmsg 收集用于后处理。

输出示例：
  uos-trace: exec mount -o ro -t ext4 /dev/sda2 /root uos-trace: mount end uos-trace: scripts/local-top/plymouth