### PR TITLE
feat(initramfs): add initramfs hook script for sw_64 architecture

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+initramfs-tools (0.142-0deepin16) unstable; urgency=medium
+
+  * Added initramfs hook script to support sw_64 architecture with required 
+  * linker and GPU firmware
+
+ -- xinpeng.wang <wangxinpeng@uniontech.com>  Wed, 17 Jun 2026 18:19:40 +0800
+
 initramfs-tools (0.142-0deepin15) unstable; urgency=medium
 
   * Optimize boot speed on UOS by stripping global wait_for_udev settle, 

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -10,3 +10,4 @@ uniontech-Improve-boot-performance-using-lz4.patch
 uniontech-add-check-fs.patch
 uniontech-add-log-for-performance.patch
 uniontech-not-wait-udev.patch
+uniontech-add-sw-support.patch

--- a/debian/patches/uniontech-add-sw-support.patch
+++ b/debian/patches/uniontech-add-sw-support.patch
@@ -1,0 +1,44 @@
+diff --git a/hooks/adaptSw b/hooks/adaptSw
+new file mode 100755
+index 0000000..fd8cd7c
+--- /dev/null
++++ b/hooks/adaptSw
+@@ -0,0 +1,38 @@
++#!/bin/sh
++## sw support.
++
++PREREQ=""
++
++prereqs()
++{
++        echo "$PREREQ"
++}
++
++case $1 in
++# get pre-requisites
++ereqs)
++        prereqs
++        exit 0
++        ;;
++esac
++
++if [ "$(uname -m)" != "sw_64" ] ;then
++	exit 0
++fi
++
++. /usr/share/initramfs-tools/hook-functions
++if [ -h /lib/ld-linux.so.2 ];then
++	copy_exec /lib/ld-linux.so.2
++fi
++
++if [ -d /lib/firmware/radeon ]
++then
++    mkdir -p ${DESTDIR}/lib/firmware/radeon/
++    cp -rpL --update=none /lib/firmware/radeon/* ${DESTDIR}/lib/firmware/radeon/ ||true
++fi
++
++if [ -d /lib/firmware/amdgpu ]
++then
++    mkdir -p ${DESTDIR}/lib/firmware/amdgpu/
++    cp -rpL --update=none /lib/firmware/amdgpu/* ${DESTDIR}/lib/firmware/amdgpu/ || true
++fi


### PR DESCRIPTION
- Add adaptSw hook script that only takes effect on sw_64 architecture
- Copy the dynamic linker /lib/ld-linux.so.2 into initramfs
- Automatically pack radeon and amdgpu firmware into the initramfs image

feat(initramfs): 添加 sw_64 架构的 initramfs hooks 脚本

- 新增 adaptSw hook 脚本，仅在 sw_64 架构下生效
- 将动态链接器 /lib/ld-linux.so.2 复制到 initramfs 中
- 自动打包 radeon 和 amdgpu 固件到 initramfs 镜像中 Bug: 366773